### PR TITLE
SendEth: add localstorage

### DIFF
--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -30,8 +30,8 @@ import React, { useEffect, useState } from "react";
 
 export default function EtherInput(props) {
   const [mode, setMode] = useState(props.price ? "USD" : "ETH");
-  const [display, setDisplay] = useState();
-  const [value, setValue] = useState();
+  const [display, setDisplay] = useState(props.value);
+  const [value, setValue] = useState(props.value);
 
   const currentValue = typeof props.value !== "undefined" ? props.value : value;
 

--- a/packages/react-app/src/components/MultiSig/SendEth.jsx
+++ b/packages/react-app/src/components/MultiSig/SendEth.jsx
@@ -1,6 +1,6 @@
 import { useContractReader } from "eth-hooks";
 import { ethers } from "ethers";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Button, Typography, Card, Tooltip } from "antd";
 import { SendOutlined, SearchOutlined } from "@ant-design/icons";
@@ -21,7 +21,8 @@ function SendEth({
   readContracts,
   contractName,
 }) {
-  //   const [to, setTo] = useLocalStorage("to", undefined);
+  const [to, setTo] = useLocalStorage("to", undefined, 60000);
+  const [amt, setAmt] = useLocalStorage("amt", 0, 60000);
   const [toAddress, setToAddress] = useState(undefined);
   const [amount, setAmount] = useState(0);
 
@@ -64,6 +65,11 @@ function SendEth({
     }
   };
 
+  useEffect(() => {
+    if (amt) setAmount(amt);
+    if (to) setToAddress(to);
+  }, []);
+
   return (
     <div>
       <div className="m-2 p-1 flex justify-center items-center border-2 rounded-lg">
@@ -73,11 +79,23 @@ function SendEth({
             ensProvider={mainnetProvider}
             placeholder={"Recepient address"}
             value={toAddress}
-            onChange={setToAddress}
+            onChange={e => {
+              setToAddress(e);
+              setTo(e);
+            }}
           />
         </div>
         <div className="p-2">
-          <EtherInput price={price} mode="USD" value={amount} onChange={setAmount} provider={localProvider} />
+          <EtherInput
+            price={price}
+            mode="USD"
+            value={amt ? amt : amount}
+            onChange={e => {
+              setAmount(e);
+              setAmt(e);
+            }}
+            provider={localProvider}
+          />
         </div>
 
         <Tooltip title="Send eth">


### PR DESCRIPTION
- used `useLocalStorage` to store `to` and `amt` in localstorage with ttl of `60000` (1m) .
- added `useEffect` which on load sets the states `toAddress` and `amount` to values from localstorage.